### PR TITLE
d3d12/GL : add DP2A

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
@@ -31,7 +31,7 @@ std::string D3D12VertexProgramDecompiler::getFunction(enum class FUNCTION f)
 	case FUNCTION::FUNCTION_DP2:
 		return "dot($0.xy, $1.xy).xxxx";
 	case FUNCTION::FUNCTION_DP2A:
-		return "";
+		return "(dot($0.xy, $1.xy) + $2.x).xxxx";
 	case FUNCTION::FUNCTION_DP3:
 		return "dot($0.xyz, $1.xyz).xxxx";
 	case FUNCTION::FUNCTION_DP4:
@@ -172,7 +172,7 @@ void D3D12VertexProgramDecompiler::insertMainStart(std::stringstream & OS)
 	for (const ParamType PT : m_parr.params[PF_PARAM_NONE])
 	{
 		for (const ParamItem &PI : PT.items)
-			OS << "	" << PT.type << " " << PI.name << " = " << PI.value << ";" << std::endl;
+			OS << "	" << PT.type << " " << PI.name << " = float4(0., 0., 0., 1.);" << std::endl;
 	}
 
 	for (const ParamType PT : m_parr.params[PF_PARAM_IN])

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -30,7 +30,7 @@ std::string GLVertexDecompilerThread::getFunction(FUNCTION f)
 	case FUNCTION::FUNCTION_DP2:
 		return "vec4(dot($0.xy, $1.xy))";
 	case FUNCTION::FUNCTION_DP2A:
-		return "";
+		return "vec4(dot($0.xy, $1.xy) + $2.x)";
 	case FUNCTION::FUNCTION_DP3:
 		return "vec4(dot($0.xyz, $1.xyz))";
 	case FUNCTION::FUNCTION_DP4:


### PR DESCRIPTION
Section 2.X.8.Z, DP2A:  2-Component Dot Product with Scalar Add

```
The DP2A instruction computes a two-component dot product of the two
operands (using the first two components), adds the x component of the
third operand, and replicates the result to all four components of the
result vector.

  tmp0 = VectorLoad(op0);
  tmp1 = VectorLoad(op1);
  tmp2 = VectorLoad(op2);
  dot = (tmp0.x * tmp1.x) + (tmp0.y * tmp1.y) + tmp2.x;
  result.x = dot;
  result.y = dot;
  result.z = dot;
  result.w = dot;

DP2A supports only floating-point data type modifiers.
```
