### PR TITLE
Renamed Symbols for `gl` branch

### DIFF
--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -57,7 +57,7 @@ LogChannel::LogChannel() : LogChannel("unknown")
 LogChannel::LogChannel(const std::string& name) :
 	  name(name)
 	, mEnabled(true)
-	, mLogLevel(Warning)
+	, mLogLevel(LogSeverityWarning)
 {}
 
 void LogChannel::log(const LogMessage &msg)
@@ -186,16 +186,16 @@ void LogManager::log(LogMessage msg)
 		std::string prefix;
 		switch (msg.mServerity)
 		{
-		case Success:
+		case LogSeveritySuccess:
 			prefix = "S ";
 			break;
-		case Notice:
+		case LogSeverityNotice:
 			prefix = "! ";
 			break;
-		case Warning:
+		case LogSeverityWarning:
 			prefix = "W ";
 			break;
-		case Error:
+		case LogSeverityError:
 			prefix = "E ";
 			break;
 		}
@@ -265,12 +265,12 @@ void log_message(Log::LogType type, Log::LogSeverity sev, std::string text)
 	else
 	{
 		rMessageBox(text,
-			sev == Notice ? "Notice" :
-			sev == Warning ? "Warning" :
-			sev == Success ? "Success" :
-			sev == Error ? "Error" : "Unknown",
-			sev == Notice ? rICON_INFORMATION :
-			sev == Warning ? rICON_EXCLAMATION :
-			sev == Error ? rICON_ERROR : rICON_INFORMATION);
+			sev == LogSeverityNotice ? "Notice" :
+			sev == LogSeverityWarning ? "Warning" :
+			sev == LogSeveritySuccess ? "Success" :
+			sev == LogSeverityError ? "Error" : "Unknown",
+			sev == LogSeverityNotice ? rICON_INFORMATION :
+			sev == LogSeverityWarning ? rICON_EXCLAMATION :
+			sev == LogSeverityError ? rICON_ERROR : rICON_INFORMATION);
 	}
 }

--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -5,10 +5,10 @@
 
 //first parameter is of type Log::LogType and text is of type std::string
 
-#define LOG_SUCCESS(logType, text, ...)           log_message(logType, Log::Success, text, ##__VA_ARGS__)
-#define LOG_NOTICE(logType, text, ...)            log_message(logType, Log::Notice,  text, ##__VA_ARGS__) 
-#define LOG_WARNING(logType, text, ...)           log_message(logType, Log::Warning, text, ##__VA_ARGS__) 
-#define LOG_ERROR(logType, text, ...)             log_message(logType, Log::Error,   text, ##__VA_ARGS__)
+#define LOG_SUCCESS(logType, text, ...)           log_message(logType, Log::LogSeveritySuccess, text, ##__VA_ARGS__)
+#define LOG_NOTICE(logType, text, ...)            log_message(logType, Log::LogSeverityNotice,  text, ##__VA_ARGS__) 
+#define LOG_WARNING(logType, text, ...)           log_message(logType, Log::LogSeverityWarning, text, ##__VA_ARGS__) 
+#define LOG_ERROR(logType, text, ...)             log_message(logType, Log::LogSeverityError,   text, ##__VA_ARGS__)
 
 namespace Log
 {
@@ -50,10 +50,10 @@ namespace Log
 
 	enum LogSeverity : u32
 	{
-		Notice = 0,
-		Warning,
-		Success,
-		Error,
+		LogSeverityNotice = 0,
+		LogSeverityWarning,
+		LogSeveritySuccess,
+		LogSeverityError,
 	};
 
 	struct LogMessage

--- a/rpcs3/Gui/ConLogFrame.cpp
+++ b/rpcs3/Gui/ConLogFrame.cpp
@@ -76,16 +76,16 @@ struct wxWriter : Log::LogListener
 				{
 					switch (msg.mServerity)
 					{
-					case Log::Notice:
+					case Log::LogSeverityNotice:
 						llogcon->SetDefaultStyle(m_color_white);
 						break;
-					case Log::Warning:
+					case Log::LogSeverityWarning:
 						llogcon->SetDefaultStyle(m_color_yellow);
 						break;
-					case Log::Error:
+					case Log::LogSeverityError:
 						llogcon->SetDefaultStyle(m_color_red);
 						break;
-					case Log::Success:
+					case Log::LogSeveritySuccess:
 						llogcon->SetDefaultStyle(m_color_green);
 						break;
 					default:


### PR DESCRIPTION
I renamed those `Notice`,`Error`,`Warning`.. enums in files directly related to Log Utilities.
This is to solve the conflicts with X11 headers and maybe some other files.
Forgive me.. I've chosen a longer name for those symbols. `Notice` to `LogSeverityNotice`.
Cause i didn't find a better word and also avoid some other commonly used names.
In my opinion it might be solved by choosing correct headers.. But unfortunately i did not do so.
If it could be solved in that way, and there is pull request for those, please tell me to close this.
TIPS: Already built the windows executable. The patches you did looks so wonderful.
